### PR TITLE
Added IdentifyPane and ResultsGrid widgets.

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,11 +1,12 @@
 define([
-    'dojo/text!app/templates/App.html',
+    'dojo/text!./templates/App.html',
 
     'dojo/_base/declare',
     'dojo/_base/array',
 
     'dojo/dom',
     'dojo/dom-style',
+    'dojo/dom-class',
 
     'dijit/_WidgetBase',
     'dijit/_TemplatedMixin',
@@ -17,9 +18,11 @@ define([
     'agrc/widgets/map/BaseMap',
     'agrc/widgets/map/BaseMapSelector',
 
-    'app/MapButton',
-    'app/Wizard',
-    'app/search/Search',
+    './MapButton',
+    './Wizard',
+    './search/Search',
+    './search/ResultsGrid',
+    './search/IdentifyPane',
 
     'ijit/widgets/authentication/LoginRegister'
 ], function(
@@ -30,6 +33,7 @@ define([
 
     dom,
     domStyle,
+    domClass,
 
     _WidgetBase,
     _TemplatedMixin,
@@ -44,6 +48,8 @@ define([
     MapButton,
     Wizard,
     Search,
+    ResultsGrid,
+    IdentifyPane,
 
     LoginRegister
 ) {
@@ -99,8 +105,11 @@ define([
                     logoutDiv: this.logoutDiv,
                     showOnLoad: false
                     // securedServicesBaseUrl: ??
-                })
+                }),
+                this.resultsGrid = new ResultsGrid({}, this.resultsGridDiv),
+                this.identifyPane = new IdentifyPane({}, this.identifyPaneDiv)
             ];
+            this.switchBottomPanel(this.resultsGridDiv);
             this.inherited(arguments);
         },
         startup: function () {
@@ -110,7 +119,9 @@ define([
         
             this.inherited(arguments);
 
+            var that = this;
             array.forEach(this.childWidgets, function (widget) {
+                that.own(widget);
                 widget.startup();
             });
 
@@ -179,6 +190,19 @@ define([
                     }
                 })
             ]);
+        },
+        switchBottomPanel: function (node) {
+            // summary:
+            //      shows the passed in node and hides the other
+            // node: DomNode
+            console.log('app/App:switchBottomPanel', arguments);
+        
+            domClass.remove(node, 'hidden');
+
+            var otherNode = (node === this.identifyPane.domNode) ? 
+                this.resultsGrid.domNode : this.identifyPane.domNode;
+
+            domClass.add(otherNode, 'hidden');
         }
     });
 });

--- a/src/app/search/IdentifyPane.js
+++ b/src/app/search/IdentifyPane.js
@@ -1,0 +1,63 @@
+define([
+    'dojo/text!./templates/IdentifyPane.html',
+
+    'dojo/_base/declare',
+
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_WidgetsInTemplateMixin'
+
+], function(
+    template,
+
+    declare,
+
+    _WidgetBase,
+    _TemplatedMixin,
+    _WidgetsInTemplateMixin
+) {
+    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+        // description:
+        //      **Summary**: Shows details about the selected search result item.
+        //      <p>
+        //      </p>
+        //      **Owner(s)**:
+        //      </p>
+        //      <p>
+        //      **Test Page**: <a href=""></a>
+        //      </p>
+        //      <p>
+        //      **Description**:  Shows details about the selected search result item.
+        //      </p>
+        //      <p>
+        //      **Required Files**:
+        //      </p>
+        //      <ul><li></li></ul>
+        // example:
+        // |    var widget = new IdentifyPane({
+        // |    }, "node");
+
+        templateString: template,
+        baseClass: 'identify-pane',
+        widgetsInTemplate: true,
+
+        // Properties to be sent into constructor
+
+        postCreate: function() {
+            // summary:
+            //    Overrides method of same name in dijit._Widget.
+            // tags:
+            //    private
+            console.log('app/search/IdentifyPane::postCreate', arguments);
+
+            this.setupConnections();
+        },
+        setupConnections: function() {
+            // summary:
+            //      wire events, and such
+            //
+            console.log('app/search/IdentifyPane::setupConnections', arguments);
+
+        }
+    });
+});

--- a/src/app/search/ResultsGrid.js
+++ b/src/app/search/ResultsGrid.js
@@ -1,0 +1,63 @@
+define([
+    'dojo/text!./templates/ResultsGrid.html',
+
+    'dojo/_base/declare',
+
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_WidgetsInTemplateMixin'
+
+], function(
+    template,
+
+    declare,
+
+    _WidgetBase,
+    _TemplatedMixin,
+    _WidgetsInTemplateMixin
+) {
+    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+        // description:
+        //      **Summary**: Sorts and displays the search results.
+        //      <p>
+        //      </p>
+        //      **Owner(s)**:
+        //      </p>
+        //      <p>
+        //      **Test Page**: <a href=""></a>
+        //      </p>
+        //      <p>
+        //      **Description**:  Sorts and displays the search results.
+        //      </p>
+        //      <p>
+        //      **Required Files**:
+        //      </p>
+        //      <ul><li></li></ul>
+        // example:
+        // |    var widget = new ResultsGrid({
+        // |    }, "node");
+
+        templateString: template,
+        baseClass: 'results-grid',
+        widgetsInTemplate: true,
+
+        // Properties to be sent into constructor
+
+        postCreate: function() {
+            // summary:
+            //    Overrides method of same name in dijit._Widget.
+            // tags:
+            //    private
+            console.log('src/app/search/ResultsGrid::postCreate', arguments);
+
+            this.setupConnections();
+        },
+        setupConnections: function() {
+            // summary:
+            //      wire events, and such
+            //
+            console.log('src/app/search/ResultsGrid::setupConnections', arguments);
+
+        }
+    });
+});

--- a/src/app/search/resources/IdentifyPane.css
+++ b/src/app/search/resources/IdentifyPane.css
@@ -1,0 +1,3 @@
+.identify-pane {
+
+}

--- a/src/app/search/resources/ResultsGrid.css
+++ b/src/app/search/resources/ResultsGrid.css
@@ -1,0 +1,3 @@
+.results-grid {
+
+}

--- a/src/app/search/templates/IdentifyPane.html
+++ b/src/app/search/templates/IdentifyPane.html
@@ -1,0 +1,3 @@
+<div>
+    Identify Pane
+</div>

--- a/src/app/search/templates/ResultsGrid.html
+++ b/src/app/search/templates/ResultsGrid.html
@@ -1,0 +1,3 @@
+<div>
+   ResultsGrid
+</div>

--- a/src/app/search/tests/IdentifyPaneTests.html
+++ b/src/app/search/tests/IdentifyPaneTests.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+    <title>IdentifyPane Tests</title>
+
+    <!-- META TAGS -->
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+    <!-- CSS -->        
+    <link rel='stylesheet' href='http://js.arcgis.com/3.7/js/dojo/dijit/themes/claro/claro.css'>
+    <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.7/js/esri/css/esri.css" />
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../resources/IdentifyPane.css">
+    <style type='text/css'>
+    
+    </style>
+
+    <!-- JAVASCRIPT -->
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
+    <script type='text/javascript' src='http://js.arcgis.com/3.8'></script>
+    <script type="text/javascript">
+    var projectUrl = location.pathname.replace(/\/[^\/]+$/, "") + '/';
+    var widgetUnderTest;
+
+    require({
+        packages: [{
+            name: 'app',
+            location: projectUrl + '../'
+        }]
+    }, [
+        'app/search/IdentifyPane',
+
+        'dojo/domReady!'
+    ], function(Module) {
+        widgetUnderTest = new Module({
+        }, 'node');
+
+        widgetUnderTest.startup();
+    });
+</script>
+</head>
+<body class='claro'>
+    <div id="node"></div>
+</body>
+</html>

--- a/src/app/search/tests/ResultsGridTests.html
+++ b/src/app/search/tests/ResultsGridTests.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+    <title>ResultsGrid Tests</title>
+
+    <!-- META TAGS -->
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+    <!-- CSS -->        
+    <link rel='stylesheet' href='http://js.arcgis.com/3.7/js/dojo/dijit/themes/claro/claro.css'>
+    <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.7/js/esri/css/esri.css" />
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../resources/ResultsGrid.css">
+    <style type='text/css'>
+    
+    </style>
+
+    <!-- JAVASCRIPT -->
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
+    <script type='text/javascript' src='http://js.arcgis.com/3.8'></script>
+    <script type="text/javascript">
+    var projectUrl = location.pathname.replace(/\/[^\/]+$/, "") + '/';
+    var widgetUnderTest;
+
+    require({
+        packages: [{
+            name: 'app',
+            location: projectUrl + '../'
+        }]
+    }, [
+        'app/search/ResultsGrid',
+
+        'dojo/domReady!'
+    ], function(Module) {
+        widgetUnderTest = new Module({
+        }, 'node');
+
+        widgetUnderTest.startup();
+    });
+</script>
+</head>
+<body class='claro'>
+    <div id="node"></div>
+</body>
+</html>

--- a/src/app/search/tests/spec/SpecIdentifyPane.js
+++ b/src/app/search/tests/spec/SpecIdentifyPane.js
@@ -1,0 +1,35 @@
+require([
+    'app/search/IdentifyPane',
+
+    'dojo/_base/window',
+
+    'dojo/dom-construct'
+], function(
+    WidgetUnderTest,
+
+    win,
+
+    domConstruct
+) {
+
+    var widget;
+
+    afterEach(function() {
+        if (widget) {
+            widget.destroyRecursive();
+            widget = null;
+        }
+    });
+
+    describe('app/search/IdentifyPane', function() {
+        describe('Sanity', function() {
+            beforeEach(function() {
+                widget = new WidgetUnderTest(null, domConstruct.create('div', null, win.body()));
+            });
+
+            it('should create a IdentifyPane', function() {
+                expect(widget).toEqual(jasmine.any(WidgetUnderTest));
+            });
+        });
+    });
+});

--- a/src/app/search/tests/spec/SpecResultsGrid.js
+++ b/src/app/search/tests/spec/SpecResultsGrid.js
@@ -1,0 +1,35 @@
+require([
+    'app/search/ResultsGrid',
+
+    'dojo/_base/window',
+
+    'dojo/dom-construct'
+], function(
+    WidgetUnderTest,
+
+    win,
+
+    domConstruct
+) {
+
+    var widget;
+
+    afterEach(function() {
+        if (widget) {
+            widget.destroy();
+            widget = null;
+        }
+    });
+
+    describe('src/app/search/ResultsGrid', function() {
+        describe('Sanity', function() {
+            beforeEach(function() {
+                widget = new WidgetUnderTest(null, domConstruct.create('div', null, win.body()));
+            });
+
+            it('should create a ResultsGrid', function() {
+                expect(widget).toEqual(jasmine.any(WidgetUnderTest));
+            });
+        });
+    });
+});

--- a/src/app/templates/App.html
+++ b/src/app/templates/App.html
@@ -26,7 +26,8 @@
         </div>
         <div data-dojo-attach-point='gridIdentifyContainer'
             class='grid-identify-container'>
-            grid/identify
+            <div data-dojo-attach-point="resultsGridDiv"></div>
+            <div data-dojo-attach-point="identifyPaneDiv" class='hidden'></div>
         </div>
     </div>
 

--- a/src/app/tests/spec/SpecApp.js
+++ b/src/app/tests/spec/SpecApp.js
@@ -1,14 +1,16 @@
 require([
     'app/App',
     'dojo/dom-construct',
-    'dojo/_base/window'
+    'dojo/_base/window',
+    'dojo/dom-class'
 
 ],
 
 function (
     App,
     domConstruct,
-    win
+    win,
+    domClass
     ) {
     describe('app/App', function () {
         var testWidget;
@@ -17,7 +19,7 @@ function (
             testWidget.startup();
         });
         afterEach(function () {
-            testWidget.destroy();
+            testWidget.destroyRecursive();
             testWidget = null;
         });
 
@@ -31,6 +33,28 @@ function (
 
                 expect(testWidget.openGridAnimation.play).toBeDefined();
                 expect(testWidget.closeGridAnimation.play).toBeDefined();
+            });
+        });
+
+        describe('switchBottomPanel', function () {
+            var panel, panel2;
+            beforeEach(function () {
+                panel = testWidget.identifyPane;
+                panel2 = testWidget.resultsGrid;
+            });
+            it('removes `hidden` class from passed in element', function () {
+                domClass.add(panel.domNode, 'hidden');
+
+                testWidget.switchBottomPanel(panel.domNode);
+
+                expect(domClass.contains(panel.domNode, 'hidden')).toBe(false);
+            });
+            it('adds `hidden` class to the other element', function () {
+                domClass.remove(panel.domNode, 'hidden');
+
+                testWidget.switchBottomPanel(panel2);
+
+                expect(domClass.contains(panel.domNode, 'hidden')).toBe(true);
             });
         });
     });


### PR DESCRIPTION
Included `switchBottomPanel` method in `app/App` to allow for switching between the two new widgets. Used plain-jane CSS instead of a StackContainer for simplicity. Closes #9.

Also updated `app/App` to pass all child widgets into `own`.
