### PR TITLE
Fixed bug in IE10+ related to the help tip

### DIFF
--- a/src/app/search/QueryLayer.js
+++ b/src/app/search/QueryLayer.js
@@ -279,6 +279,16 @@ define([
 
             evt.preventDefault();
             evt.stopPropagation();
+        },
+        onHelpTipClick: function (evt) {
+            // summary:
+            //      fix bug in IE10+ that causes the checkbox to toggle
+            //      when clicking on the help tip
+            // evt: mouse click object
+            console.log('app/QueryLayer:onHelpTipClick', arguments);
+        
+            evt.preventDefault();
+            window.open(this.helpTip.href, 'new');
         }
     });
 });

--- a/src/app/search/templates/QueryLayer.html
+++ b/src/app/search/templates/QueryLayer.html
@@ -8,6 +8,7 @@
                 data-toggle='tooltip'
                 data-delay='${popupDelay}'
                 data-dojo-attach-point='helpTip'
+                data-dojo-attach-event='click: onHelpTipClick'
                 title='${description}'>
                 <span class="glyphicon glyphicon-question-sign"></span>
             </a>


### PR DESCRIPTION
When clicking on the help tip the query layer checkbox was incorrectly toggling.

Closes #285