### PR TITLE
Better feature selection/highlighting

### DIFF
--- a/src/app/config.js
+++ b/src/app/config.js
@@ -91,7 +91,8 @@ define([
                 zoomToSearchGraphic: 'app/map/MapController.zoomToSearchGraphic',
                 graphic: 'app/map/MapController.graphic',
                 clearGraphics: 'app/map/MapController.clearGraphics',
-                zoom: 'app/map/MapController.zoom'
+                zoom: 'app/map/MapController.zoom',
+                showHighlightedFeature: 'app/map/MapController.showHighlightedFeature'
             },
             appSearch: {
                 featuresFound: 'app/search/Search.featuresFound',
@@ -167,7 +168,8 @@ define([
                 TYPE: 'TYPE',
                 UNIQUE_ID: 'UNIQUE_ID',
                 ENVIROAPPLABEL: 'ENVIROAPPLABEL',
-                ENVIROAPPSYMBOL: 'ENVIROAPPSYMBOL'
+                ENVIROAPPSYMBOL: 'ENVIROAPPSYMBOL',
+                OBJECTID: 'OBJECTID'
             }
         },
 

--- a/src/app/map/tests/spec/SpecMapController.js
+++ b/src/app/map/tests/spec/SpecMapController.js
@@ -1,11 +1,11 @@
 require([
+    'app/config',
     'app/map/MapController',
 
     'esri/layers/ArcGISDynamicMapServiceLayer',
     'esri/layers/ArcGISTiledMapServiceLayer'
-
-
 ], function(
+    config,
     ClassUnderTest,
 
     ArcGISDynamicMapServiceLayer,
@@ -169,9 +169,9 @@ require([
                 };
                 testObject.searchGraphics = null;
 
-                testObject.graphic(g);
+                testObject.graphic('test', config.symbols.zoom, g);
 
-                expect(testObject.searchGraphics).toBeDefined();
+                expect(testObject.test).toBeDefined();
             });
         });
     });

--- a/src/app/search/ResultLayer.js
+++ b/src/app/search/ResultLayer.js
@@ -253,14 +253,17 @@ define([
             //      clears selection and selects if appropriate
             // oid: Number
             // layerIndex: String
-            // console.log('app/search/ResultLayer:onHighlight', arguments);
-
-            this.fLayer.clearSelection();
+            console.log('app/search/ResultLayer:onHighlight', arguments);
 
             if (layerIndex === this.layerIndex) {
                 var query = new Query();
                 query.objectIds = [oid];
-                this.fLayer.selectFeatures(query);
+                this.fLayer.queryFeatures(query).then(function (fSet) {
+                    if (fSet.features.length > 0) {
+                        topic.publish(config.topics.appMapMapController.showHighlightedFeature,
+                            fSet.features[0].geometry);
+                    }
+                });
             }
         },
         onClick: function (evt) {
@@ -269,6 +272,8 @@ define([
             //      fires topic to initiate an identify on that feature
             // evt: Object graphic click
             console.log('app/search/ResultLayer:onClick', arguments);
+
+            evt.stopPropagation();
 
             var g = evt.graphic;
             g.attributes.parent = this.layerIndex;

--- a/src/app/search/ResultsGrid.js
+++ b/src/app/search/ResultsGrid.js
@@ -387,7 +387,7 @@ define([
                     });
                 }
                 graphic.attributes.parent = layerIndex;
-                graphic.attributes[fn.UNIQUE_ID] = layerIndex + '-' + graphic.attributes[fn.ID];
+                graphic.attributes[fn.UNIQUE_ID] = layerIndex + '-' + graphic.attributes[fn.OBJECTID];
                 graphic.attributes.geometry = graphic.geometry;
                 return graphic.attributes;
             };

--- a/src/app/search/tests/data/results.json
+++ b/src/app/search/tests/data/results.json
@@ -6,7 +6,8 @@
             "ADDRESS": "n/a",
             "CITY": "n/a",
             "TYPE": "D ",
-            "ENVIROAPPSYMBOL": "n/a"
+            "ENVIROAPPSYMBOL": "n/a",
+            "OBJECTID": 1234
         },
         "geometry": {
             "x": 325975.0,
@@ -219,7 +220,8 @@
             "ADDRESS": "10622 WEST 6400 NORTH",
             "CITY": "CEDAR CITY",
             "TYPE": "TRI Facilities - 84720MRCNZ10622",
-            "ENVIROAPPSYMBOL": "n/a"
+            "ENVIROAPPSYMBOL": "n/a",
+            "OBJECTID": 5678
         },
         "geometry": {
             "x": 298816.29000000004,

--- a/src/app/search/tests/spec/SpecResultLayer.js
+++ b/src/app/search/tests/spec/SpecResultLayer.js
@@ -56,13 +56,15 @@ require([
                     attributes: {OBJECTID: oid},
                     geometry: geo
                 };
-                testObject.onClick({graphic: g});
+                var spy = jasmine.createSpy('stopPropagation');
+                testObject.onClick({graphic: g, stopPropagation: spy});
 
                 expect(config.topics.appSearch.identify).toHaveBeenPublishedWith({
                     parent: testObject.layerIndex,
                     geometry: geo,
                     OBJECTID: oid
                 });
+                expect(spy).toHaveBeenCalled();
             });
         });
     });

--- a/src/app/search/tests/spec/SpecResultsGrid.js
+++ b/src/app/search/tests/spec/SpecResultsGrid.js
@@ -128,8 +128,8 @@ require([
                 expect(result[6][fn.UNIQUE_ID]).toEqual('5-' + config.messages.noFeaturesFound);
 
                 // features
-                expect(result[8][fn.UNIQUE_ID]).toEqual('7-4302110758');
-                expect(result[3][fn.UNIQUE_ID]).toEqual('15-84720MRCNZ10622');
+                expect(result[8][fn.UNIQUE_ID]).toEqual('7-1234');
+                expect(result[3][fn.UNIQUE_ID]).toEqual('15-5678');
             });
             it('adds feature counts to id field', function () {
                 expect(result[0].count).toEqual('0');


### PR DESCRIPTION
Especially for overlapping polygons. This was accomplished by creating a separate graphics layer to hold selected features rather than selecting the feature directly through the FeatureLayer. Selecting features via the feature layer caused drawing order issues in layers that had overlapping polygons.

Added map click listener to clear any selected feature to allow users to click off of features to unselect them.

Switched unique id in grid to use OBJECTID's instead of ID's.

Closes #281