### PR TITLE
Empty DeqEnviro.json

### DIFF
--- a/scripts/nightly/build_json.py
+++ b/scripts/nightly/build_json.py
@@ -30,9 +30,9 @@ def run():
     j = {fieldnames.queryLayers: layers,
          fieldnames.relatedTables: tables,
          fieldnames.otherLinks: linksDict}
-    f = open(jsonFile, 'w')
-    print >> f, json.dumps(j, indent=4)
-    f.close()
+    
+    with open(jsonFile, 'w') as f:
+        json.dump(j, f)
 
     return j
 


### PR DESCRIPTION
I think [this file](https://github.com/agrc/deq-enviro/blob/master/scripts/nightly/build_json.py) needs 2to3 run on it and printing to a file doesn't work in py3.

