### PR TITLE
Fix SGID update code

### DIFF
--- a/scripts/nightly/update_sgid.py
+++ b/scripts/nightly/update_sgid.py
@@ -36,7 +36,7 @@ def update_sgid_for_crates(crates_from_slip):
         owner_connection = settings.sgid[sgid_name.split('.')[1]]
         destination = path.join(owner_connection, sgid_name)
 
-        if sgid_name.startswith('SGID'):
+        if sgid_name.casefold().startswith('sgid'):
             logger.info(f'updating {sgid_name}')
             scratch = Path(arcpy.env.scratchFolder) / 'deq_data_for_sgid.gdb'
             source = crate_slip['destination']


### PR DESCRIPTION
This was not excluding deq datasets that had their source as tables in SGID. So it was pulling the data from SGID during lift and then pushing it back to SGID during ship. To make matters worse, it was using Append which doesn't have the ability to accept a geographic transformation so the data was being projected incorrectly.

I have this branch checked out on the server at the moment to test. Seems like it's good to go but might be best to wait until Monday.