### PR TITLE
fix(download): increase max cloud run instances

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
           service: download
           flags: |
             --service-account=cloud-run-sa@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
-            --max-instances=10
+            --max-instances=30
             --min-instances=0
             --allow-unauthenticated
             --memory=${{ env.MEMORY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   MEMORY: 4G
-  TIMEOUT: 20m
+  TIMEOUT: 30m
   TRIGGER_PARAMS: |
     --location=nam5 \
     --destination-run-service=download \


### PR DESCRIPTION
This service was being hammered last week and returning lots of 429 HTTP status codes. Ref: https://cloud.google.com/run/docs/troubleshooting#abort-request