### PR TITLE
fix(download): break up related tables queries to avoid new AGOL database errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "a",
     "ACLINK",
     "ae",
+    "agol",
     "anotherfield",
     "arcgis",
     "arcpy",

--- a/cloudrun/src/download/agol.py
+++ b/cloudrun/src/download/agol.py
@@ -29,6 +29,7 @@ gdal.UseExceptions()
 output_folder = Path("/tmp") / "output"
 fgdb_path = output_folder / "data.gdb"
 formats_with_shape = ["filegdb", "geojson", "shapefile"]
+max_in_values = 2000
 
 
 def cleanup():
@@ -175,7 +176,7 @@ def create_relationship(
 
     existing_ids = related_table_primary_keys.setdefault(related_table_name, set())
     requested_ids = set(primary_keys)
-    new_ids = requested_ids - set(existing_ids)
+    new_ids = list(requested_ids - existing_ids)
     related_table_primary_keys[related_table_name] = existing_ids | requested_ids
 
     if not new_ids:
@@ -183,30 +184,57 @@ def create_relationship(
 
         return
 
-    if get_field_type(config["primary"], fields) in [
-        "esriFieldTypeString",
-        "esriFieldTypeGUID",
-    ]:
-        ids = [f"'{x}'" for x in new_ids]
-    else:
-        ids = [str(x) for x in new_ids]
+    field_type = get_field_type(config["primary"], fields)
+    wrote_related_features = False
+    nested_relationships = config.get("nestedRelationships", [])
+    nested_primary_keys = [set() for _ in nested_relationships]
+    related_fields = None
+    for start in range(0, len(new_ids), max_in_values):
+        query_ids = new_ids[start : start + max_in_values]
+        if field_type in ["esriFieldTypeString", "esriFieldTypeGUID"]:
+            ids = [f"'{value}'" for value in query_ids]
+        else:
+            ids = [str(value) for value in query_ids]
 
-    where = f"{config['foreign']} IN " + f"({','.join(ids)})"
-    related_feature_set = get_agol_data(
-        config["url"],
-        None,
-        return_geometry,
-        where=where,
-    )
+        where = f"{config['foreign']} IN " + f"({','.join(ids)})"
+        related_feature_set = get_agol_data(
+            config["url"],
+            None,
+            return_geometry,
+            where=where,
+        )
 
-    if len(related_feature_set.features) == 0:
-        logger.info("no features found, skipping creation")
+        if len(related_feature_set.features) == 0:
+            logger.info("no features found, skipping creation")
 
-        return
+            continue
 
-    write_to_output(related_table_name, related_feature_set, format)
+        write_to_output(related_table_name, related_feature_set, format)
+        wrote_related_features = True
 
-    if format == "filegdb":
+        for index, nested_relationship in enumerate(nested_relationships):
+            nested_primary_keys[index].update(
+                related_feature_set.sdf.reset_index()[
+                    nested_relationship["primary"]
+                ].tolist()
+            )
+        related_fields = related_feature_set.fields
+
+    for nested_relationship, nested_keys in zip(
+        nested_relationships, nested_primary_keys
+    ):
+        if nested_keys:
+            create_relationship(
+                nested_relationship,
+                nested_keys,
+                related_fields,
+                return_geometry,
+                related_table_name,
+                format,
+                related_table_primary_keys,
+            )
+
+    if format == "filegdb" and wrote_related_features:
         relationship = gdal.Relationship(
             config["name"],
             parent_name,
@@ -220,20 +248,6 @@ def create_relationship(
         output_dataset = gdal.OpenEx(str(fgdb_path), gdal.GA_Update)
         if not output_dataset.AddRelationship(relationship):
             logger.info("failed to add relationship")
-
-    if "nestedRelationships" in config:
-        for nested_relationship in config["nestedRelationships"]:
-            create_relationship(
-                nested_relationship,
-                related_feature_set.sdf.reset_index()[
-                    nested_relationship["primary"]
-                ].tolist(),
-                related_feature_set.fields,
-                return_geometry,
-                related_table_name,
-                format,
-                related_table_primary_keys,
-            )
 
 
 def get_agol_data(

--- a/cloudrun/tests/test_agol.py
+++ b/cloudrun/tests/test_agol.py
@@ -1,6 +1,121 @@
 from download import agol
 
 
+def test_create_relationship_batches_primary_keys(mocker):
+    get_agol_data = mocker.patch("download.agol.get_agol_data")
+    primary_keys = list(range(agol.max_in_values + 1))
+    config = {
+        "name": "parent_to_related",
+        "tableName": "related",
+        "url": "https://example.com/FeatureServer/0",
+        "primary": "parent_id",
+        "foreign": "parent_id",
+    }
+
+    agol.create_relationship(
+        config,
+        primary_keys,
+        [{"name": "parent_id", "type": "esriFieldTypeInteger"}],
+        False,
+        "parent",
+        "csv",
+        {},
+    )
+
+    assert get_agol_data.call_count == 2
+    assert all(
+        call.kwargs["where"].count(",") < agol.max_in_values
+        for call in get_agol_data.call_args_list
+    )
+
+
+def test_create_relationship_adds_filegdb_relationship_once(mocker, monkeypatch):
+    get_agol_data = mocker.patch("download.agol.get_agol_data")
+    mocker.patch("download.agol.write_to_output")
+    relationship = mocker.patch("download.agol.gdal.Relationship")
+    output_dataset = mocker.Mock()
+    mocker.patch("download.agol.gdal.OpenEx", return_value=output_dataset)
+    feature_set = mocker.Mock()
+    feature_set.features = [mocker.Mock()]
+    get_agol_data.side_effect = [feature_set, feature_set]
+    monkeypatch.setattr(agol, "max_in_values", 1)
+    config = {
+        "name": "parent_to_related",
+        "tableName": "related",
+        "url": "https://example.com/FeatureServer/0",
+        "primary": "parent_id",
+        "foreign": "parent_id",
+    }
+
+    agol.create_relationship(
+        config,
+        [1, 2],
+        [{"name": "parent_id", "type": "esriFieldTypeInteger"}],
+        False,
+        "parent",
+        "filegdb",
+        {},
+    )
+
+    relationship.assert_called_once()
+    output_dataset.AddRelationship.assert_called_once()
+
+
+def test_create_relationship_batches_nested_relationship_keys(mocker):
+    get_agol_data = mocker.patch("download.agol.get_agol_data")
+    mocker.patch("download.agol.write_to_output")
+    parent_keys = list(range(agol.max_in_values + 1))
+    nested_keys = list(range(1, agol.max_in_values + 1))
+
+    def related_feature_set(primary_keys):
+        feature_set = mocker.Mock()
+        feature_set.features = [mocker.Mock()]
+        primary_key_column = mocker.Mock()
+        primary_key_column.tolist.return_value = primary_keys
+        feature_set.sdf.reset_index.return_value = {"child_id": primary_key_column}
+        feature_set.fields = [{"name": "child_id", "type": "esriFieldTypeInteger"}]
+        return feature_set
+
+    empty_feature_set = mocker.Mock()
+    empty_feature_set.features = []
+    get_agol_data.side_effect = [
+        related_feature_set(nested_keys[: agol.max_in_values // 2]),
+        related_feature_set(nested_keys[agol.max_in_values // 2 :]),
+        empty_feature_set,
+    ]
+    config = {
+        "name": "parent_to_related",
+        "tableName": "related",
+        "url": "https://example.com/FeatureServer/0",
+        "primary": "parent_id",
+        "foreign": "parent_id",
+        "nestedRelationships": [
+            {
+                "name": "related_to_child",
+                "tableName": "child",
+                "url": "https://example.com/FeatureServer/1",
+                "primary": "child_id",
+                "foreign": "child_id",
+            }
+        ],
+    }
+
+    agol.create_relationship(
+        config,
+        parent_keys,
+        [{"name": "parent_id", "type": "esriFieldTypeInteger"}],
+        False,
+        "parent",
+        "csv",
+        {},
+    )
+
+    assert get_agol_data.call_count == 3
+    nested_where = get_agol_data.call_args_list[2].kwargs["where"]
+    assert nested_where.startswith("child_id IN ")
+    assert {int(value) for value in nested_where[13:-1].split(",")} == set(nested_keys)
+
+
 def test_create_relationship_skips_query_without_new_primary_keys(mocker):
     get_agol_data = mocker.patch("download.agol.get_agol_data")
     config = {


### PR DESCRIPTION
AGOL recently made changes restricting the length of where clauses. I fixed the front end yesterday, this is to fix the back end download service.